### PR TITLE
fix newwork page table is too wide(fix网络->接口菜单显示)

### DIFF
--- a/htdocs/luci-static/edge/cascade.css
+++ b/htdocs/luci-static/edge/cascade.css
@@ -3996,7 +3996,7 @@ i input {
 
 .cbi-map >.cbi-section .cbi-section-table,.container .cbi-tabmenu,.container #tabmenu,.cbi-map >.cbi-section .table {
 	margin-left: -2%;
-    width: 105%;
+    width: 100%;
 }
 
 .admin-status-overview h2.content {


### PR DESCRIPTION
On page network , inerface menu , table is too wide, Causes incomplete display of delete button
在网络页面, 接口菜单，列表table宽度过长，导致删除按钮显示不全